### PR TITLE
[SeatPage] 예매 하기 버튼

### DIFF
--- a/lib/pages/seat/seat_page.dart
+++ b/lib/pages/seat/seat_page.dart
@@ -83,6 +83,10 @@ class _SeatPageState extends State<SeatPage> {
                                   ),
                                 ),
                                 CupertinoDialogAction(
+                                  onPressed: () {
+                                    Navigator.pop(context);
+                                    Navigator.pop(context);
+                                  },
                                   child: Text(
                                     '확인',
                                     style: TextStyle(color: Colors.blue),


### PR DESCRIPTION
### 🚀 개요
선택된 좌석이 없으면 예매 버튼이 비활성화된다.
선택된 좌석이 있으면 showCupertinoDialog이 표시되며, 
취소를 클릭하면 Dialog이 제거되고,
확인을 클릭하면 HomePage로 이동(뒤로가기 두번)한다.

### 🔧 변경사항
- 예매 하기 버튼 추가
- CupertinoAlertDialog UI 구현
- 확인 버튼 클릭 시, HomePage로 이동
- 취소 버튼 클릭 시, Dialog 제거

### 💡issue : #12 